### PR TITLE
Fix: Persist stream message state to prevent duplicates on restart

### DIFF
--- a/db_manager.py
+++ b/db_manager.py
@@ -37,24 +37,65 @@ async def remove_config(conn: aiosqlite.Connection, category: str, key: str):
     await conn.commit()
     return cursor.rowcount > 0
 
+# --- Functions for Posted Streams ---
+
+async def add_posted_stream(conn: aiosqlite.Connection, stream_id: str, message_id: int, channel_id: int):
+    """Adds a record of a posted stream message to the database."""
+    await conn.execute(
+        "INSERT OR REPLACE INTO posted_streams (stream_id, message_id, channel_id) VALUES (?, ?, ?)",
+        (stream_id, message_id, channel_id)
+    )
+    await conn.commit()
+
+async def remove_posted_stream(conn: aiosqlite.Connection, stream_id: str):
+    """Removes a posted stream record from the database."""
+    await conn.execute("DELETE FROM posted_streams WHERE stream_id = ?", (stream_id,))
+    await conn.commit()
+
+async def get_all_posted_streams(conn: aiosqlite.Connection) -> dict:
+    """Retrieves all posted stream records from the database."""
+    async with conn.execute("SELECT stream_id, message_id, channel_id FROM posted_streams") as cursor:
+        rows = await cursor.fetchall()
+        # The key in current_stream_msgs is f"{channel.id}_{stream_id}"
+        # We need to reconstruct this from the database
+        return {
+            f"{row['channel_id']}_{row['stream_id']}": {
+                "stream_id": row['stream_id'],
+                "msg_id": row['message_id'],
+                "channel_id": row['channel_id']
+            } for row in rows
+        }
+
+
 def initialize_db():
-    """Initializes the database and creates the config table if it doesn't exist,
+    """Initializes the database and creates tables if they don't exist,
     prompting for essential credentials if they are not found.
     This function remains synchronous as it's part of the initial setup.
     """
     conn = sqlite3.connect(DATABASE_NAME)
     conn.row_factory = sqlite3.Row
     cursor = conn.cursor()
+
+    # --- Config Table ---
     cursor.execute("""
         CREATE TABLE IF NOT EXISTS config (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             category TEXT NOT NULL,
-            key TEXT UNIQUE NOT NULL,
-            value TEXT NOT NULL
+            key TEXT NOT NULL,
+            value TEXT NOT NULL,
+            UNIQUE(category, key)
         )
     """)
-    # Check for unique constraint on category and key together
-    cursor.execute("CREATE UNIQUE INDEX IF NOT EXISTS idx_category_key ON config (category, key)")
+
+    # --- Posted Streams Table ---
+    cursor.execute("""
+        CREATE TABLE IF NOT EXISTS posted_streams (
+            stream_id TEXT PRIMARY KEY,
+            message_id INTEGER NOT NULL,
+            channel_id INTEGER NOT NULL
+        )
+    """)
+
     conn.commit()
 
     # Synchronous get_config for initialization

--- a/main.py
+++ b/main.py
@@ -61,6 +61,10 @@ class StreamBot(commands.Bot):
         self.db_conn = await db_manager.connect_db()
         logging.info("Database connection established.")
 
+        # --- Load existing stream messages from DB ---
+        self.current_stream_msgs = await db_manager.get_all_posted_streams(self.db_conn)
+        logging.info(f"Loaded {len(self.current_stream_msgs)} tracked stream messages from the database.")
+
         # --- Twitch API Client ---
         client_id = await db_manager.get_config(self.db_conn, 'credentials', 'twitch_client_id')
         client_secret = await db_manager.get_config(self.db_conn, 'credentials', 'twitch_client_secret')
@@ -191,6 +195,7 @@ class StreamBot(commands.Bot):
                         msg = await channel.send(embed=embed)
                         msg_key = f"{channel.id}_{stream_id}"
                         self.current_stream_msgs[msg_key] = {"stream_id": stream_id, "msg_id": msg.id, "channel_id": channel.id}
+                        await db_manager.add_posted_stream(self.db_conn, stream_id, msg.id, channel.id)
                     except Exception as e:
                         logging.error(f"Failed to send message for stream {stream_id} in guild {guild.id}: {e}")
 
@@ -210,6 +215,9 @@ class StreamBot(commands.Bot):
                         pass # Message was already deleted
                     except Exception as e:
                         logging.error(f"Failed to delete message {msg_info['msg_id']} for stream {stream_id}: {e}")
+                # Always remove from DB even if channel/message deletion fails,
+                # as the stream is no longer live.
+                await db_manager.remove_posted_stream(self.db_conn, stream_id)
 
     def _create_stream_embed(self, stream: dict) -> discord.Embed:
         """Creates a Discord embed for a given stream."""


### PR DESCRIPTION
The bot was previously using an in-memory dictionary to cache the messages it had posted for active streams. When the bot restarted (either manually or due to the built-in restart-on-error mechanism), this in-memory state was lost.

This led to a race condition where, upon restarting, the bot would see currently live streams as "new" and post a second notification for them, resulting in duplicate messages in the channel.

This commit fixes the issue by persisting the state of posted stream messages in the SQLite database.

- A new table `posted_streams` is added to the database to store the stream ID, message ID, and channel ID of each notification.
- On startup, the bot now loads the state from this table into its cache.
- The database is kept in sync as streams are posted and as their notifications are removed.

This ensures that the bot's state is durable and survives restarts, preventing the creation of duplicate stream notifications.